### PR TITLE
fix: make the spdx output more complete

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ GOLINTER_VERSION := v1.52.2
 
 # OCI registry
 ZOT := $(TOOLSDIR)/bin/zot
-ZOT_VERSION := 2.0.0-rc5
+ZOT_VERSION := 2.0.0
 # OCI registry clients
 ORAS := $(TOOLSDIR)/bin/oras
 ORAS_VERSION := 1.0.0-rc.1

--- a/test/bom.bats
+++ b/test/bom.bats
@@ -18,7 +18,7 @@ function teardown() {
   docker run -v ${TOPDIR}/bin:/opt/bin -v ${BOMD}:/stacker-artifacts -i ubuntu:latest /opt/bin/stacker-bom-linux-amd64 discover -o /stacker-artifacts/discover.json
   [ -f ${BOMD}/discover.json ]
   # verify against inventory
-  ${TOPDIR}/bin/stacker-bom-linux-amd64 verify -i ${BOMD}/discover.json -t ${BOMD}/inventory.json -m ${BOMD}/missing.json
+  docker run -v ${TOPDIR}/bin:/opt/bin -v ${BOMD}:/stacker-artifacts -i ubuntu:latest /opt/bin/stacker-bom-linux-amd64 verify -i /stacker-artifacts/discover.json -t  /stacker-artifacts/inventory.json -m  /stacker-artifacts/missing.json
   [ ! -f ${BOMD}/missing.json ]
   # push the image
   skopeo copy --format=oci --dest-tls-verify=false docker://ubuntu:latest docker://${ZOT_HOST}:${ZOT_PORT}/ubuntu:latest


### PR DESCRIPTION
sha1 checksums are commonly checked by existing scanners/tools. Some of the fields are not set, so set them.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
